### PR TITLE
Python unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_script:
 script:
   - go vet "$LZONE/..."
   - "$GOPATH/src/github.com/codecov/example-go/go.test.sh"
-  - cd "$API"; coverage run --include="$API/*.py" -m unittest discover
+  - cd "$API"; coverage run --include="$(pwd)/*.py" --omit="$(pwd)/test*.py" -m unittest discover
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ go:
 env:
   global:
     - BACKEND="$HOME/gopath/src/github.com/seadsystem/Backend"
-    - API="$BACKEND/DB/api"
+    - API="$TRAVIS_BUILD_DIR/DB/api"
     - LZONE="$BACKEND/DB/landingzone"
 
 addons:
@@ -39,6 +39,6 @@ script:
   - cd "$API"; coverage run --include="$API/*.py" -m unittest discover
 
 after_success:
-  - coveralls
+  - cd "$API"; coveralls
   - rm "$API/.coverage"
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ go:
 env:
   global:
     - BACKEND="$HOME/gopath/src/github.com/seadsystem/Backend"
-    - API="$TRAVIS_BUILD_DIR/DB/api"
+    - API="$BACKEND/DB/api"
     - LZONE="$BACKEND/DB/landingzone"
 
 addons:
@@ -39,6 +39,6 @@ script:
   - cd "$API"; coverage run --include="$API/*.py" -m unittest discover
 
 after_success:
-  - cd "$API"; coveralls
+  - coveralls
   - rm "$API/.coverage"
   - bash <(curl -s https://codecov.io/bash)

--- a/DB/landingzone/constants/constants_test.go
+++ b/DB/landingzone/constants/constants_test.go
@@ -1,0 +1,1 @@
+package constants

--- a/DB/landingzone/handlers/seadPlugHandlers/seadPlugHandlers_test.go
+++ b/DB/landingzone/handlers/seadPlugHandlers/seadPlugHandlers_test.go
@@ -1,0 +1,1 @@
+package seadPlugHandlers

--- a/DB/landingzone/main_test.go
+++ b/DB/landingzone/main_test.go
@@ -1,0 +1,1 @@
+package main


### PR DESCRIPTION
 Improve unit test coverage tracking by excluding test files for Python tests and including packages with no tests for Go tests.

It doesn't make sense to include unit tests in code coverage because unlike properly written non-test code, you don't actually want to write tests where every line is executed. A good test will have error checking logic which is not executed when the test passes.

I think it is pretty obvious why we want to includes packages without any tests in our coverage calculation.